### PR TITLE
Add wget to the prereq. packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 class cpanel {
 	
-	package { "perl":    ensure => "installed"}
+	package { ["wget", "perl"]:    ensure => "installed"}
 	
     exec { "install_cpanel":
 		cwd => "/home",


### PR DESCRIPTION
Found out that we need to have the wget ifn you install a minimal centos or netinstall.

So adding this small change
